### PR TITLE
feat: improvements from feedbacks

### DIFF
--- a/mock/simple-api.json
+++ b/mock/simple-api.json
@@ -12,48 +12,14 @@
       "uuid": "de4b66da-06ed-4fad-b044-705339fb40c1",
       "type": "http",
       "documentation": "",
-      "method": "post",
-      "endpoint": "question",
+      "method": "get",
+      "endpoint": "limits",
       "responses": [
         {
           "uuid": "39c8ef9d-0227-4903-ae7f-34d77267785f",
-          "body": "{\n  \"id\": \"question-123\"\n}",
+          "body": "{\n  \"retrospective\": {\n  \"name\": 100,\n  \"description\": 300,\n    }\n  },\n  \"question\": {\n    \"text\": 300\n  },\n  \"answer\": {\n    \"text\": 600\n  }\n}",
           "latency": 0,
-          "statusCode": 201,
-          "label": "",
-          "headers": [],
-          "bodyType": "INLINE",
-          "filePath": "",
-          "databucketID": "",
-          "sendFileAsBody": false,
-          "rules": [
-            {
-              "target": "body",
-              "modifier": "question",
-              "value": "",
-              "invert": true,
-              "operator": "null"
-            },
-            {
-              "target": "cookie",
-              "modifier": "retrospective_id",
-              "value": "retro-123",
-              "invert": false,
-              "operator": "equals"
-            }
-          ],
-          "rulesOperator": "AND",
-          "disableTemplating": false,
-          "fallbackTo404": false,
-          "default": false,
-          "crudKey": "id",
-          "callbacks": []
-        },
-        {
-          "uuid": "13bb66ee-5827-48e9-945b-f3477716bebf",
-          "body": "{\n  \"error\": \"This retro doesnt exists\"\n}",
-          "latency": 0,
-          "statusCode": 404,
+          "statusCode": 200,
           "label": "",
           "headers": [],
           "bodyType": "INLINE",
@@ -61,7 +27,7 @@
           "databucketID": "",
           "sendFileAsBody": false,
           "rules": [],
-          "rulesOperator": "OR",
+          "rulesOperator": "AND",
           "disableTemplating": false,
           "fallbackTo404": false,
           "default": true,
@@ -97,12 +63,20 @@
       "value": "application/json"
     },
     {
-      "key": "Access-Control-Allow-Origin",
-      "value": "*"
+      "key": "Access-Control-Allow-Methods",
+      "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
     },
     {
-      "key": "Set-Cookie",
-      "value": "retrospective_id=retro-123"
+      "key": "Access-Control-Allow-Headers",
+      "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"
+    },
+    {
+      "key": "Access-Control-Allow-Origin",
+      "value": "http://localhost:5173"
+    },
+    {
+      "key": "Access-Control-Allow-Credentials",
+      "value": "true"
     }
   ],
   "proxyReqHeaders": [

--- a/src/components/answer/AnswerInputs.vue
+++ b/src/components/answer/AnswerInputs.vue
@@ -1,16 +1,24 @@
 <script setup lang="ts">
+  import { computed } from 'vue';
   import { useLimistStore } from '../../stores/limitsStore';
   import BaseButton from '../core/BaseButton.vue';
+  import LimitLabel from '../core/LimitLabel.vue';
 
   const limitsStore = useLimistStore();
 
-  const { answer } = defineProps<{
+  const props = defineProps<{
     answer: string;
     label: string;
     placeholder: string;
     buttonLabel: string;
     disabled: boolean;
   }>();
+
+  const charactersLeft = computed(() => {
+    const limit = limitsStore.limits?.answer.text ?? 0;
+
+    return limit - props.answer.length;
+  });
 
   const emit = defineEmits<{
     'update:answer': [string];
@@ -19,12 +27,11 @@
 </script>
 
 <template>
-  <label for="answer" class="block mb-2 text-md font-bold text-gray-900">
-    {{ label }}
-  </label>
+  <LimitLabel :characters-left="charactersLeft" :label="label" label-for="answer" />
 
   <textarea
     id="answer"
+    aria-describedby="left-question"
     :value="answer"
     :disabled="disabled || !limitsStore.limits"
     :maxlength="limitsStore.limits?.answer.text"

--- a/src/components/answer/AnswerInputs.vue
+++ b/src/components/answer/AnswerInputs.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+  import { useLimistStore } from '../../stores/limitsStore';
+  import BaseButton from '../core/BaseButton.vue';
+
+  const limitsStore = useLimistStore();
+
+  const { answer } = defineProps<{
+    answer: string;
+    label: string;
+    placeholder: string;
+    buttonLabel: string;
+    disabled: boolean;
+  }>();
+
+  const emit = defineEmits<{
+    'update:answer': [string];
+    clicked: [];
+  }>();
+</script>
+
+<template>
+  <label for="answer" class="block mb-2 text-md font-bold text-gray-900">
+    {{ label }}
+  </label>
+
+  <textarea
+    id="answer"
+    :value="answer"
+    :disabled="disabled || !limitsStore.limits"
+    :maxlength="limitsStore.limits?.answer.text"
+    rows="4"
+    class="block mb-5 p-2.5 resize-none w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-75"
+    :placeholder="placeholder"
+    @input="emit('update:answer', ($event.target as HTMLInputElement).value)"
+  />
+
+  <BaseButton
+    :disabled="
+      disabled ||
+      answer.length < 1 ||
+      !limitsStore.limits ||
+      answer.length > limitsStore.limits.answer.text
+    "
+    class="w-full"
+    @click="emit('clicked')"
+  >
+    {{ buttonLabel }}
+  </BaseButton>
+</template>

--- a/src/components/answer/AnswerLayout.vue
+++ b/src/components/answer/AnswerLayout.vue
@@ -6,7 +6,7 @@
   import PageDivider from '../core/PageDivider.vue';
   import DeleteAnswer from './DeleteAnswer.vue';
 
-  const { answer } = defineProps<{
+  defineProps<{
     answer: Answer;
   }>();
 
@@ -24,7 +24,7 @@
   <div>
     <div class="flex flex-col cursor-pointer" @click="controlAnswerModal(answer)">
       <i class="absolute">•</i>
-      <div class="text-black ml-5 whitespace-pre-line">{{ answer.text }}</div>
+      <div class="text-black ml-5 whitespace-pre-line break-all">{{ answer.text }}</div>
     </div>
 
     <ModalifyComponent v-if="isControlModalOpen" @close="isControlModalOpen = false">

--- a/src/components/answer/AnswerLayout.vue
+++ b/src/components/answer/AnswerLayout.vue
@@ -24,7 +24,7 @@
   <div>
     <div class="flex flex-col cursor-pointer" @click="controlAnswerModal(answer)">
       <i class="absolute">•</i>
-      <div class="text-black ml-5">{{ answer.text }}</div>
+      <div class="text-black ml-5 whitespace-pre-line">{{ answer.text }}</div>
     </div>
 
     <ModalifyComponent v-if="isControlModalOpen" @close="isControlModalOpen = false">

--- a/src/components/answer/CreateAnswer.vue
+++ b/src/components/answer/CreateAnswer.vue
@@ -11,7 +11,7 @@
   const answer = ref('');
   const disableInteraction = ref(false);
 
-  const { question, questionIndex } = defineProps<{
+  const props = defineProps<{
     question: Question;
     questionIndex: number;
   }>();
@@ -23,7 +23,7 @@
 
     disableInteraction.value = true;
 
-    const res = await answerApi.createAnswer(answer.value, question.id);
+    const res = await answerApi.createAnswer(answer.value, props.question.id);
 
     emits('fetched', { success: res.error === undefined });
 
@@ -32,7 +32,7 @@
     if (res.error)
       return notifyStore.notify('An error occured to create the question', NotificationType.Error);
 
-    retroStore.answer.createAnswer({ ...res, question_id: question.id });
+    retroStore.answer.createAnswer({ ...res, question_id: props.question.id });
   };
 </script>
 

--- a/src/components/answer/CreateAnswer.vue
+++ b/src/components/answer/CreateAnswer.vue
@@ -4,9 +4,15 @@
   import { NotificationType, useNotifyStore } from '../../stores/notifyStore';
   import { Question, useRetrospectiveStore } from '../../stores/retrospectiveStore';
   import BaseButton from '../core/BaseButton.vue';
+  import { useLimistStore } from '../../stores/limitsStore';
+  import { storeToRefs } from 'pinia';
 
   const notifyStore = useNotifyStore();
   const retroStore = useRetrospectiveStore();
+  const limitsStore = useLimistStore();
+
+  const { limits } = storeToRefs(limitsStore);
+
   const answer = ref('');
   const disableIntearction = ref(false);
 
@@ -43,14 +49,17 @@
   <textarea
     id="answer"
     v-model="answer"
-    :disabled="disableIntearction"
+    :disabled="disableIntearction || !limits"
+    :maxlength="limits?.answer.text"
     rows="4"
     class="block mb-5 p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-75"
     :placeholder="question.text"
   />
 
   <BaseButton
-    :disabled="disableIntearction || answer.length < 1"
+    :disabled="
+      disableIntearction || answer.length < 1 || !limits || answer.length > limits.answer.text
+    "
     class="w-full"
     @click="createAnswer"
   >

--- a/src/components/answer/CreateAnswer.vue
+++ b/src/components/answer/CreateAnswer.vue
@@ -3,18 +3,13 @@
   import answerApi from '../../services/answerApi';
   import { NotificationType, useNotifyStore } from '../../stores/notifyStore';
   import { Question, useRetrospectiveStore } from '../../stores/retrospectiveStore';
-  import BaseButton from '../core/BaseButton.vue';
-  import { useLimistStore } from '../../stores/limitsStore';
-  import { storeToRefs } from 'pinia';
+  import AnswerInputs from './AnswerInputs.vue';
 
   const notifyStore = useNotifyStore();
   const retroStore = useRetrospectiveStore();
-  const limitsStore = useLimistStore();
-
-  const { limits } = storeToRefs(limitsStore);
 
   const answer = ref('');
-  const disableIntearction = ref(false);
+  const disableInteraction = ref(false);
 
   const { question, questionIndex } = defineProps<{
     question: Question;
@@ -26,13 +21,13 @@
   const createAnswer = async () => {
     if (answer.value.length < 1) return;
 
-    disableIntearction.value = true;
+    disableInteraction.value = true;
 
     const res = await answerApi.createAnswer(answer.value, question.id);
 
     emits('fetched', { success: res.error === undefined });
 
-    disableIntearction.value = false;
+    disableInteraction.value = false;
 
     if (res.error)
       return notifyStore.notify('An error occured to create the question', NotificationType.Error);
@@ -42,27 +37,13 @@
 </script>
 
 <template>
-  <label for="answer" class="block mb-2 text-md font-bold text-gray-900">
-    {{ `Q${questionIndex}. Your answer` }}
-  </label>
-
-  <textarea
-    id="answer"
-    v-model="answer"
-    :disabled="disableIntearction || !limits"
-    :maxlength="limits?.answer.text"
-    rows="4"
-    class="block mb-5 p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-75"
+  <AnswerInputs
+    :label="`Q${questionIndex}. Your answer`"
+    :answer="answer"
     :placeholder="question.text"
+    button-label="Send answer"
+    :disabled="disableInteraction"
+    @clicked="createAnswer"
+    @update:answer="($event) => (answer = $event)"
   />
-
-  <BaseButton
-    :disabled="
-      disableIntearction || answer.length < 1 || !limits || answer.length > limits.answer.text
-    "
-    class="w-full"
-    @click="createAnswer"
-  >
-    Send answer
-  </BaseButton>
 </template>

--- a/src/components/answer/DeleteAnswer.vue
+++ b/src/components/answer/DeleteAnswer.vue
@@ -12,24 +12,24 @@
     close: [];
   }>();
 
-  const { answer } = defineProps<{
+  const props = defineProps<{
     answer: Answer;
   }>();
 
   const confirmedId = ref('');
 
   const deleteAnswer = async () => {
-    if (confirmedId.value !== answer.id) {
-      confirmedId.value = answer.id;
+    if (confirmedId.value !== props.answer.id) {
+      confirmedId.value = props.answer.id;
       return;
     }
 
-    const res = await answerApi.deleteAnswer(answer.id);
+    const res = await answerApi.deleteAnswer(props.answer.id);
 
     if (res?.error)
       return notifyStore.notify('An error occured to delete the answer', NotificationType.Error);
 
-    retroStore.answer.deleteAnswer(answer);
+    retroStore.answer.deleteAnswer(props.answer);
 
     emits('close');
   };

--- a/src/components/answer/UpdateAnswer.vue
+++ b/src/components/answer/UpdateAnswer.vue
@@ -1,17 +1,12 @@
 <script setup lang="ts">
   import { ref } from 'vue';
-  import BaseButton from '../core/BaseButton.vue';
   import { NotificationType, useNotifyStore } from '../../stores/notifyStore';
   import { Answer, useRetrospectiveStore } from '../../stores/retrospectiveStore';
   import answerApi from '../../services/answerApi';
-  import { useLimistStore } from '../../stores/limitsStore';
-  import { storeToRefs } from 'pinia';
+  import AnswerInputs from './AnswerInputs.vue';
 
   const retroStore = useRetrospectiveStore();
   const notifyStore = useNotifyStore();
-  const limitsStore = useLimistStore();
-
-  const { limits } = storeToRefs(limitsStore);
 
   const emits = defineEmits<{
     close: [];
@@ -22,6 +17,7 @@
   }>();
 
   const updatedText = ref(answer.text);
+  const disableInteraction = ref(false);
 
   const updateAnswer = async () => {
     if (updatedText.value === answer.text) {
@@ -29,7 +25,9 @@
       return;
     }
 
+    disableInteraction.value = true;
     const res = await answerApi.editAnswer({ ...answer, text: updatedText.value });
+    disableInteraction.value = false;
 
     if (res.error)
       return notifyStore.notify(
@@ -44,21 +42,13 @@
 </script>
 
 <template>
-  <label for="answer" class="block mb-2 text-md font-bold text-gray-900">Update answer</label>
-  <textarea
-    id="answer"
-    v-model="updatedText"
-    :maxlength="limits?.answer.text"
-    :disabled="!limits"
-    rows="6"
-    class="flex mb-5 p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 disabled:opacity-75"
+  <AnswerInputs
+    label="Update answer"
+    :answer="updatedText"
     placeholder="Eat potato..."
+    button-label="Update answer"
+    :disabled="disableInteraction"
+    @clicked="updateAnswer"
+    @update:answer="($event) => (updatedText = $event)"
   />
-
-  <BaseButton
-    class="w-full"
-    :disabled="!limits || updatedText.length > limits.answer.text"
-    @click="updateAnswer"
-    >Update answer</BaseButton
-  >
 </template>

--- a/src/components/answer/UpdateAnswer.vue
+++ b/src/components/answer/UpdateAnswer.vue
@@ -4,9 +4,14 @@
   import { NotificationType, useNotifyStore } from '../../stores/notifyStore';
   import { Answer, useRetrospectiveStore } from '../../stores/retrospectiveStore';
   import answerApi from '../../services/answerApi';
+  import { useLimistStore } from '../../stores/limitsStore';
+  import { storeToRefs } from 'pinia';
 
   const retroStore = useRetrospectiveStore();
   const notifyStore = useNotifyStore();
+  const limitsStore = useLimistStore();
+
+  const { limits } = storeToRefs(limitsStore);
 
   const emits = defineEmits<{
     close: [];
@@ -43,10 +48,17 @@
   <textarea
     id="answer"
     v-model="updatedText"
+    :maxlength="limits?.answer.text"
+    :disabled="!limits"
     rows="6"
     class="flex mb-5 p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 disabled:opacity-75"
     placeholder="Eat potato..."
   />
 
-  <BaseButton class="w-full" @click="updateAnswer">Update answer</BaseButton>
+  <BaseButton
+    class="w-full"
+    :disabled="!limits || updatedText.length > limits.answer.text"
+    @click="updateAnswer"
+    >Update answer</BaseButton
+  >
 </template>

--- a/src/components/answer/UpdateAnswer.vue
+++ b/src/components/answer/UpdateAnswer.vue
@@ -12,21 +12,21 @@
     close: [];
   }>();
 
-  const { answer } = defineProps<{
+  const props = defineProps<{
     answer: Answer;
   }>();
 
-  const updatedText = ref(answer.text);
+  const updatedText = ref(props.answer.text);
   const disableInteraction = ref(false);
 
   const updateAnswer = async () => {
-    if (updatedText.value === answer.text) {
+    if (updatedText.value === props.answer.text) {
       emits('close');
       return;
     }
 
     disableInteraction.value = true;
-    const res = await answerApi.editAnswer({ ...answer, text: updatedText.value });
+    const res = await answerApi.editAnswer({ ...props.answer, text: updatedText.value });
     disableInteraction.value = false;
 
     if (res.error)

--- a/src/components/core/ContactInfo.vue
+++ b/src/components/core/ContactInfo.vue
@@ -3,7 +3,7 @@
   import LinkedinIcon from '../icons/LinkedinIcon.vue';
   import WebsiteIcon from '../icons/WebsiteIcon.vue';
 
-  const { name, role, avatar, githubUser, linkedinUser, websiteLink } = defineProps<{
+  defineProps<{
     name: string;
     role: string;
     avatar: string;

--- a/src/components/core/KnownRetros.vue
+++ b/src/components/core/KnownRetros.vue
@@ -3,7 +3,7 @@
   import { useRouter } from 'vue-router';
 
   const router = useRouter();
-  const { retros } = defineProps<{ retros: KnownRetro[] }>();
+  defineProps<{ retros: KnownRetro[] }>();
 
   const redirectToRetro = (retroId: string) => {
     router.push({ name: 'retrospective.view', params: { id: retroId } });

--- a/src/components/core/LimitLabel.vue
+++ b/src/components/core/LimitLabel.vue
@@ -1,5 +1,19 @@
 <script setup lang="ts">
-  defineProps<{ charactersLeft: number; labelFor: string; label: string }>();
+  import { ref, watch } from 'vue';
+
+  const shouldBounce = ref(false);
+  let clearBounceTimeout: number;
+
+  const props = defineProps<{ charactersLeft: number; labelFor: string; label: string }>();
+
+  watch(props, () => {
+    clearTimeout(clearBounceTimeout);
+    shouldBounce.value = true;
+
+    clearBounceTimeout = setTimeout(() => {
+      shouldBounce.value = false;
+    }, 190);
+  });
 </script>
 
 <template>
@@ -9,7 +23,12 @@
       <span
         v-if="charactersLeft <= 30"
         :id="`left-${labelFor}`"
-        class="text-red-600 font-semibold"
+        :class="{
+          'font-semibold': true,
+          bounce: shouldBounce,
+          'text-red-500': charactersLeft <= 10,
+          'text-gray-400': charactersLeft > 10,
+        }"
         aria-live="polite"
         aria-atomic="true"
       >
@@ -18,3 +37,25 @@
     </Transition>
   </div>
 </template>
+
+<style scoped>
+  @keyframes bounce {
+    0%,
+    20%,
+    50%,
+    80%,
+    100% {
+      transform: translateY(0);
+    }
+    40% {
+      transform: translateY(-10px);
+    }
+    60% {
+      transform: translateY(-5px);
+    }
+  }
+
+  .bounce {
+    animation: bounce 0.2s infinite;
+  }
+</style>

--- a/src/components/core/LimitLabel.vue
+++ b/src/components/core/LimitLabel.vue
@@ -7,6 +7,7 @@
   const props = defineProps<{ charactersLeft: number; labelFor: string; label: string }>();
 
   watch(props, () => {
+    if (props.charactersLeft > 10) return;
     clearTimeout(clearBounceTimeout);
     shouldBounce.value = true;
 

--- a/src/components/core/LimitLabel.vue
+++ b/src/components/core/LimitLabel.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+  defineProps<{ charactersLeft: number; labelFor: string; label: string }>();
+</script>
+
+<template>
+  <div class="flex justify-between">
+    <label :for="labelFor" class="text-md font-bold text-gray-900">{{ label }}</label>
+    <Transition name="fade">
+      <span
+        v-if="charactersLeft <= 30"
+        :id="`left-${labelFor}`"
+        class="text-red-600 font-semibold"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {{ charactersLeft }}
+      </span>
+    </Transition>
+  </div>
+</template>

--- a/src/components/core/ModalifyComponent.vue
+++ b/src/components/core/ModalifyComponent.vue
@@ -7,7 +7,7 @@
     emit('close');
   };
 
-  const { extraClasses } = defineProps<{ extraClasses?: string }>();
+  defineProps<{ extraClasses?: string }>();
 </script>
 
 <template>

--- a/src/components/icons/ClosedEyeIcon.vue
+++ b/src/components/icons/ClosedEyeIcon.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  const { size } = defineProps<{ size: number }>();
+  defineProps<{ size: number }>();
 </script>
 
 <template>

--- a/src/components/icons/EditIcon.vue
+++ b/src/components/icons/EditIcon.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  const { size } = defineProps<{ size: number }>();
+  defineProps<{ size: number }>();
 </script>
 
 <template>

--- a/src/components/icons/GithubIcon.vue
+++ b/src/components/icons/GithubIcon.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  const { extraClasses } = defineProps<{ extraClasses?: string }>();
+  defineProps<{ extraClasses?: string }>();
 </script>
 <template>
   <svg

--- a/src/components/icons/OpenEyeIcon.vue
+++ b/src/components/icons/OpenEyeIcon.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  const { size } = defineProps<{ size: number }>();
+  defineProps<{ size: number }>();
 </script>
 
 <template>

--- a/src/components/icons/QuestionIcon.vue
+++ b/src/components/icons/QuestionIcon.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  const { size } = defineProps<{ size: number }>();
+  defineProps<{ size: number }>();
 </script>
 
 <template>

--- a/src/components/icons/ShareIcon.vue
+++ b/src/components/icons/ShareIcon.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  const { size } = defineProps<{ size: number }>();
+  defineProps<{ size: number }>();
 </script>
 
 <template>

--- a/src/components/icons/TelegramIcon.vue
+++ b/src/components/icons/TelegramIcon.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  const { size } = defineProps<{ size: number }>();
+  defineProps<{ size: number }>();
 </script>
 
 <template>

--- a/src/components/icons/UserIcon.vue
+++ b/src/components/icons/UserIcon.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  const { extraClasses } = defineProps<{ extraClasses?: string }>();
+  defineProps<{ extraClasses?: string }>();
 </script>
 <template>
   <svg

--- a/src/components/question/CreateQuestion.vue
+++ b/src/components/question/CreateQuestion.vue
@@ -4,9 +4,14 @@
   import { NotificationType, useNotifyStore } from '../../stores/notifyStore';
   import { useRetrospectiveStore } from '../../stores/retrospectiveStore';
   import BaseButton from '../core/BaseButton.vue';
+  import { useLimistStore } from '../../stores/limitsStore';
+  import { storeToRefs } from 'pinia';
 
   const notifyStore = useNotifyStore();
   const retroStore = useRetrospectiveStore();
+  const limitsStore = useLimistStore();
+
+  const { limits } = storeToRefs(limitsStore);
   const question = ref('');
   const disableIntearction = ref(false);
 
@@ -35,14 +40,17 @@
   <textarea
     id="question"
     v-model="question"
-    :disabled="disableIntearction"
+    :disabled="disableIntearction || !limits"
+    :maxlength="limits?.question.text"
     rows="4"
     class="flex mb-5 p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-75"
     placeholder="When you were a child..."
   />
 
   <BaseButton
-    :disabled="disableIntearction || question.length < 5"
+    :disabled="
+      disableIntearction || question.length < 5 || !limits || question.length > limits.question.text
+    "
     class="w-full"
     @click="createQuestion"
   >

--- a/src/components/question/CreateQuestion.vue
+++ b/src/components/question/CreateQuestion.vue
@@ -3,28 +3,22 @@
   import questionApi from '../../services/questionApi';
   import { NotificationType, useNotifyStore } from '../../stores/notifyStore';
   import { useRetrospectiveStore } from '../../stores/retrospectiveStore';
-  import BaseButton from '../core/BaseButton.vue';
-  import { useLimistStore } from '../../stores/limitsStore';
-  import { storeToRefs } from 'pinia';
+  import QuestionInputs from './QuestionInputs.vue';
 
   const notifyStore = useNotifyStore();
   const retroStore = useRetrospectiveStore();
-  const limitsStore = useLimistStore();
 
-  const { limits } = storeToRefs(limitsStore);
   const question = ref('');
-  const disableIntearction = ref(false);
+  const disableInteraction = ref(false);
 
   const emits = defineEmits<{ fetched: [{ success: boolean }] }>();
 
   const createQuestion = async () => {
     if (question.value.length < 5) return;
 
-    disableIntearction.value = true;
-
+    disableInteraction.value = true;
     const res = await questionApi.createQuestion(question.value);
-
-    disableIntearction.value = false;
+    disableInteraction.value = false;
 
     emits('fetched', { success: res.error === undefined });
 
@@ -36,24 +30,12 @@
 </script>
 
 <template>
-  <label for="question" class="block mb-2 text-md font-bold text-gray-900">Create a question</label>
-  <textarea
-    id="question"
-    v-model="question"
-    :disabled="disableIntearction || !limits"
-    :maxlength="limits?.question.text"
-    rows="4"
-    class="flex mb-5 p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-75"
-    placeholder="When you were a child..."
+  <QuestionInputs
+    button-label="Create question"
+    label="Create a question"
+    :disabled="disableInteraction"
+    :question="question"
+    @update:question="($event) => (question = $event)"
+    @clicked="createQuestion"
   />
-
-  <BaseButton
-    :disabled="
-      disableIntearction || question.length < 5 || !limits || question.length > limits.question.text
-    "
-    class="w-full"
-    @click="createQuestion"
-  >
-    Create question
-  </BaseButton>
 </template>

--- a/src/components/question/DeleteQuestion.vue
+++ b/src/components/question/DeleteQuestion.vue
@@ -11,18 +11,18 @@
 
   const isOpen = ref(false);
 
-  const { question, questionIndex } = defineProps<{
+  const props = defineProps<{
     question: Question;
     questionIndex: number;
   }>();
 
   const deleteQuestion = async () => {
-    const res = await questionApi.deleteQuestion(question.id);
+    const res = await questionApi.deleteQuestion(props.question.id);
 
     if (res?.error)
       return notifyStore.notify('An error occured to delete the question', NotificationType.Error);
 
-    retroStore.question.deleteQuestion(question);
+    retroStore.question.deleteQuestion(props.question);
 
     isOpen.value = !isOpen.value;
   };

--- a/src/components/question/QuestionInputs.vue
+++ b/src/components/question/QuestionInputs.vue
@@ -1,15 +1,23 @@
 <script setup lang="ts">
+  import { computed } from 'vue';
   import { useLimistStore } from '../../stores/limitsStore';
   import BaseButton from '../core/BaseButton.vue';
+  import LimitLabel from '../core/LimitLabel.vue';
 
   const limitsStore = useLimistStore();
 
-  const { question } = defineProps<{
+  const props = defineProps<{
     question: string;
     label: string;
     buttonLabel: string;
     disabled: boolean;
   }>();
+
+  const charactersLeft = computed(() => {
+    const limit = limitsStore.limits?.question.text ?? 0;
+
+    return limit - props.question.length;
+  });
 
   const emit = defineEmits<{
     'update:question': [string];
@@ -18,9 +26,10 @@
 </script>
 
 <template>
-  <label for="question" class="block mb-2 text-md font-bold text-gray-900">{{ label }}</label>
+  <LimitLabel :characters-left="charactersLeft" :label="label" label-for="question" />
   <textarea
     id="question"
+    aria-describedby="left-question"
     :value="question"
     :disabled="disabled || !limitsStore.limits"
     :maxlength="limitsStore.limits?.question.text"

--- a/src/components/question/QuestionInputs.vue
+++ b/src/components/question/QuestionInputs.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+  import { useLimistStore } from '../../stores/limitsStore';
+  import BaseButton from '../core/BaseButton.vue';
+
+  const limitsStore = useLimistStore();
+
+  const { question } = defineProps<{
+    question: string;
+    label: string;
+    buttonLabel: string;
+    disabled: boolean;
+  }>();
+
+  const emit = defineEmits<{
+    'update:question': [string];
+    clicked: [];
+  }>();
+</script>
+
+<template>
+  <label for="question" class="block mb-2 text-md font-bold text-gray-900">{{ label }}</label>
+  <textarea
+    id="question"
+    :value="question"
+    :disabled="disabled || !limitsStore.limits"
+    :maxlength="limitsStore.limits?.question.text"
+    rows="4"
+    class="flex mb-5 p-2.5 resize-none w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-75"
+    placeholder="When you were a child..."
+    @input="emit('update:question', ($event.target as HTMLInputElement).value)"
+  />
+
+  <BaseButton
+    :disabled="
+      disabled ||
+      question.length < 5 ||
+      !limitsStore.limits ||
+      question.length > limitsStore.limits.question.text
+    "
+    class="w-full"
+    @click="emit('clicked')"
+  >
+    {{ buttonLabel }}
+  </BaseButton>
+</template>

--- a/src/components/question/QuestionLayout.vue
+++ b/src/components/question/QuestionLayout.vue
@@ -17,7 +17,7 @@
   }>();
 
   const isCreateModalOpen = ref(false);
-  const answersAreShown = ref(false);
+  const answersAreShown = ref(true);
 
   const toggleCreateAnswerModal = () => {
     isCreateModalOpen.value = !isCreateModalOpen.value;

--- a/src/components/question/QuestionLayout.vue
+++ b/src/components/question/QuestionLayout.vue
@@ -10,7 +10,7 @@
   import OpenEyeIcon from '../icons/OpenEyeIcon.vue';
   import ClosedEyeIcon from '../icons/ClosedEyeIcon.vue';
 
-  const { question, questionIndex, editable } = defineProps<{
+  defineProps<{
     question: Question;
     questionIndex: number;
     editable: boolean;
@@ -40,7 +40,8 @@
 
     <div class="flex justify-between items-center">
       <p
-        class="text-xl max-w-3xl font-bold break-word flex gap-2 cursor-pointer"
+        class="text-xl font-bold break-all flex gap-2 cursor-pointer"
+        :class="{ 'max-w-3xl': editable, 'max-w-4xl': !editable }"
         @click="toggleDisplayAnswers"
       >
         {{ `Q${questionIndex}. ${question.text}` }}

--- a/src/components/question/QuestionLayout.vue
+++ b/src/components/question/QuestionLayout.vue
@@ -44,8 +44,8 @@
         @click="toggleDisplayAnswers"
       >
         {{ `Q${questionIndex}. ${question.text}` }}
-        <OpenEyeIcon v-if="answersAreShown" :size="24" />
-        <ClosedEyeIcon v-else :size="24" />
+        <OpenEyeIcon v-if="answersAreShown" class="flex flex-shrink-0" :size="24" />
+        <ClosedEyeIcon v-else class="flex flex-shrink-0" :size="24" />
       </p>
 
       <div class="flex gap-2 flex-shrink-0">

--- a/src/components/question/UpdateQuestion.vue
+++ b/src/components/question/UpdateQuestion.vue
@@ -5,16 +5,13 @@
   import { NotificationType, useNotifyStore } from '../../stores/notifyStore';
   import questionApi from '../../services/questionApi';
   import { Question, useRetrospectiveStore } from '../../stores/retrospectiveStore';
-  import { useLimistStore } from '../../stores/limitsStore';
-  import { storeToRefs } from 'pinia';
+  import QuestionInputs from './QuestionInputs.vue';
 
   const retroStore = useRetrospectiveStore();
   const notifyStore = useNotifyStore();
-  const limitsStore = useLimistStore();
-
-  const { limits } = storeToRefs(limitsStore);
 
   const isOpen = ref(false);
+  const disableInteraction = ref(false);
 
   const { question, questionIndex } = defineProps<{
     question: Question;
@@ -29,7 +26,9 @@
       return;
     }
 
+    disableInteraction.value = true;
     const res = await questionApi.editQuestion({ ...question, text: updatedText.value });
+    disableInteraction.value = false;
 
     if (res?.error)
       return notifyStore.notify(
@@ -51,25 +50,14 @@
 
 <template>
   <ModalifyComponent v-if="isOpen" @close="isOpen = false">
-    <label for="question" class="block mb-2 text-md font-bold text-gray-900">
-      {{ `Q${questionIndex}. Update question` }}
-    </label>
-    <textarea
-      id="question"
-      v-model="updatedText"
-      :disabled="!limits"
-      :maxlength="limits?.question.text"
-      rows="4"
-      class="flex mb-5 p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 disabled:opacity-75"
-      placeholder="When you were a child..."
+    <QuestionInputs
+      button-label="Update question"
+      :label="`Q${questionIndex}. Update question`"
+      :disabled="disableInteraction"
+      :question="updatedText"
+      @update:question="($event) => (updatedText = $event)"
+      @clicked="updateQuestion"
     />
-
-    <BaseButton
-      class="w-full"
-      :disabled="!limits || updatedText.length > limits.question.text"
-      @click="updateQuestion"
-      >Update question</BaseButton
-    >
   </ModalifyComponent>
 
   <BaseButton @click="openModal"><span>Update question</span></BaseButton>

--- a/src/components/question/UpdateQuestion.vue
+++ b/src/components/question/UpdateQuestion.vue
@@ -5,9 +5,14 @@
   import { NotificationType, useNotifyStore } from '../../stores/notifyStore';
   import questionApi from '../../services/questionApi';
   import { Question, useRetrospectiveStore } from '../../stores/retrospectiveStore';
+  import { useLimistStore } from '../../stores/limitsStore';
+  import { storeToRefs } from 'pinia';
 
   const retroStore = useRetrospectiveStore();
   const notifyStore = useNotifyStore();
+  const limitsStore = useLimistStore();
+
+  const { limits } = storeToRefs(limitsStore);
 
   const isOpen = ref(false);
 
@@ -52,12 +57,19 @@
     <textarea
       id="question"
       v-model="updatedText"
+      :disabled="!limits"
+      :maxlength="limits?.question.text"
       rows="4"
       class="flex mb-5 p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 disabled:opacity-75"
       placeholder="When you were a child..."
     />
 
-    <BaseButton class="w-full" @click="updateQuestion">Update question</BaseButton>
+    <BaseButton
+      class="w-full"
+      :disabled="!limits || updatedText.length > limits.question.text"
+      @click="updateQuestion"
+      >Update question</BaseButton
+    >
   </ModalifyComponent>
 
   <BaseButton @click="openModal"><span>Update question</span></BaseButton>

--- a/src/components/question/UpdateQuestion.vue
+++ b/src/components/question/UpdateQuestion.vue
@@ -13,21 +13,21 @@
   const isOpen = ref(false);
   const disableInteraction = ref(false);
 
-  const { question, questionIndex } = defineProps<{
+  const props = defineProps<{
     question: Question;
     questionIndex: number;
   }>();
 
-  const updatedText = ref(question.text);
+  const updatedText = ref(props.question.text);
 
   const updateQuestion = async () => {
-    if (updatedText.value === question.text) {
+    if (updatedText.value === props.question.text) {
       isOpen.value = false;
       return;
     }
 
     disableInteraction.value = true;
-    const res = await questionApi.editQuestion({ ...question, text: updatedText.value });
+    const res = await questionApi.editQuestion({ ...props.question, text: updatedText.value });
     disableInteraction.value = false;
 
     if (res?.error)

--- a/src/components/retrospective/CreateRetrospective.vue
+++ b/src/components/retrospective/CreateRetrospective.vue
@@ -5,8 +5,11 @@
   import { useRetrospectiveStore } from '../../stores/retrospectiveStore';
   import { useRouter } from 'vue-router';
   import BaseButton from '../core/BaseButton.vue';
+  import { useLimistStore } from '../../stores/limitsStore';
+  import { storeToRefs } from 'pinia';
 
   const notifyStore = useNotifyStore();
+  const limitsStore = useLimistStore();
   const retroStore = useRetrospectiveStore();
   const router = useRouter();
 
@@ -14,6 +17,7 @@
   const retroDescription = ref('');
   const disableIntearction = ref(false);
 
+  const { limits } = storeToRefs(limitsStore);
   const createRetrospective = async () => {
     disableIntearction.value = true;
 
@@ -38,7 +42,8 @@
     <input
       id="name"
       v-model="retroName"
-      :disabled="disableIntearction"
+      :disabled="disableIntearction || !limits"
+      :maxlength="limits?.retrospective.name"
       rows="4"
       class="flex p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-75"
       placeholder="When you were a child..."
@@ -48,14 +53,21 @@
     <textarea
       id="description"
       v-model="retroDescription"
-      :disabled="disableIntearction"
+      :disabled="disableIntearction || !limits"
+      :maxlength="limits?.retrospective.description"
       rows="4"
       class="flex mb-5 p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-75"
       placeholder="Retrospective to talk about sprint 123, gather some feedback and be better!"
     />
 
     <BaseButton
-      :disabled="disableIntearction || retroName.length < 5"
+      :disabled="
+        disableIntearction ||
+        retroName.length < 5 ||
+        !limits ||
+        retroName.length > limits.retrospective.name ||
+        retroDescription.length > limits.retrospective.description
+      "
       class="w-full"
       @click="createRetrospective"
     >

--- a/src/components/retrospective/CreateRetrospective.vue
+++ b/src/components/retrospective/CreateRetrospective.vue
@@ -4,26 +4,20 @@
   import { NotificationType, useNotifyStore } from '../../stores/notifyStore';
   import { useRetrospectiveStore } from '../../stores/retrospectiveStore';
   import { useRouter } from 'vue-router';
-  import BaseButton from '../core/BaseButton.vue';
-  import { useLimistStore } from '../../stores/limitsStore';
-  import { storeToRefs } from 'pinia';
+  import RetrospectiveInputs from './RetrospectiveInputs.vue';
 
   const notifyStore = useNotifyStore();
-  const limitsStore = useLimistStore();
   const retroStore = useRetrospectiveStore();
   const router = useRouter();
 
   const retroName = ref('');
   const retroDescription = ref('');
-  const disableIntearction = ref(false);
+  const disableInteraction = ref(false);
 
-  const { limits } = storeToRefs(limitsStore);
   const createRetrospective = async () => {
-    disableIntearction.value = true;
-
+    disableInteraction.value = true;
     const retro = await retroApi.createRetrospective(retroName.value, retroDescription.value);
-
-    disableIntearction.value = false;
+    disableInteraction.value = false;
 
     if (retro.error)
       return notifyStore.notify(
@@ -37,41 +31,13 @@
 </script>
 
 <template>
-  <div class="flex flex-col gap-2">
-    <label for="name" class="text-md font-bold text-gray-900">Name</label>
-    <input
-      id="name"
-      v-model="retroName"
-      :disabled="disableIntearction || !limits"
-      :maxlength="limits?.retrospective.name"
-      rows="4"
-      class="flex p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-75"
-      placeholder="When you were a child..."
-    />
-
-    <label for="description" class="text-md font-bold text-gray-900">Description</label>
-    <textarea
-      id="description"
-      v-model="retroDescription"
-      :disabled="disableIntearction || !limits"
-      :maxlength="limits?.retrospective.description"
-      rows="4"
-      class="flex mb-5 p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-75"
-      placeholder="Retrospective to talk about sprint 123, gather some feedback and be better!"
-    />
-
-    <BaseButton
-      :disabled="
-        disableIntearction ||
-        retroName.length < 5 ||
-        !limits ||
-        retroName.length > limits.retrospective.name ||
-        retroDescription.length > limits.retrospective.description
-      "
-      class="w-full"
-      @click="createRetrospective"
-    >
-      Create retrospective
-    </BaseButton>
-  </div>
+  <RetrospectiveInputs
+    button-label="Create retrospective"
+    :retro-name="retroName"
+    :disabled="disableInteraction"
+    :retro-description="retroDescription"
+    @clicked="createRetrospective"
+    @update:retro-name="($event) => (retroName = $event)"
+    @update:retro-description="($event) => (retroDescription = $event)"
+  />
 </template>

--- a/src/components/retrospective/DeleteRetrospective.vue
+++ b/src/components/retrospective/DeleteRetrospective.vue
@@ -11,12 +11,12 @@
 
   const isOpen = ref(false);
 
-  const { retrospective } = defineProps<{
+  const props = defineProps<{
     retrospective: Retrospective;
   }>();
 
   const deleteRetrospective = async () => {
-    const res = await retrospectiveApi.deleteRestrospective(retrospective.id);
+    const res = await retrospectiveApi.deleteRestrospective(props.retrospective.id);
 
     if (res?.error)
       return notifyStore.notify(

--- a/src/components/retrospective/ManageRetrospective.vue
+++ b/src/components/retrospective/ManageRetrospective.vue
@@ -34,7 +34,7 @@
       <div class="flex flex-col">
         <div class="flex justify-between items-center">
           <h1 class="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl">
-            <div class="cursor-pointer" @click="toogleEditRetroModal">
+            <div class="cursor-pointer break-all" @click="toogleEditRetroModal">
               {{ retrospective.name }}
               <EditIcon class="inline" :size="42" />
             </div>
@@ -45,7 +45,7 @@
             <DeleteRetrospective :retrospective="retrospective" />
           </div>
         </div>
-        <p v-if="retrospective.description" class="text-gray-500">
+        <p v-if="retrospective.description" class="text-gray-500 break-all">
           {{ retrospective.description }}
         </p>
         <BaseButton

--- a/src/components/retrospective/RetrospectiveInputs.vue
+++ b/src/components/retrospective/RetrospectiveInputs.vue
@@ -1,15 +1,29 @@
 <script setup lang="ts">
+  import { computed } from 'vue';
   import { useLimistStore } from '../../stores/limitsStore';
   import BaseButton from '../core/BaseButton.vue';
+  import LimitLabel from '../core/LimitLabel.vue';
 
   const limitsStore = useLimistStore();
 
-  const { retroName, retroDescription } = defineProps<{
+  const props = defineProps<{
     retroName: string;
     retroDescription: string | undefined;
     buttonLabel: string;
     disabled: boolean;
   }>();
+
+  const charactersLeftForName = computed(() => {
+    const limit = limitsStore.limits?.retrospective.name ?? 0;
+
+    return limit - props.retroName.length;
+  });
+
+  const charactersLeftForDescription = computed(() => {
+    const limit = limitsStore.limits?.retrospective.description ?? 0;
+
+    return limit - (props.retroDescription?.length ?? 0);
+  });
 
   const emit = defineEmits<{
     'update:retroName': [string];
@@ -20,9 +34,10 @@
 
 <template>
   <div class="flex flex-col gap-2">
-    <label for="name" class="text-md font-bold text-gray-900">Name</label>
+    <LimitLabel :characters-left="charactersLeftForName" label="Name" label-for="name" />
     <input
       id="name"
+      aria-describedby="left-name"
       :value="retroName"
       :disabled="disabled || !limitsStore.limits"
       :maxlength="limitsStore.limits?.retrospective.name"
@@ -32,9 +47,14 @@
       @input="emit('update:retroName', ($event.target as HTMLInputElement).value)"
     />
 
-    <label for="description" class="text-md font-bold text-gray-900">Description</label>
+    <LimitLabel
+      :characters-left="charactersLeftForDescription"
+      label="Description"
+      label-for="description"
+    />
     <textarea
       id="description"
+      aria-describedby="left-description"
       :value="retroDescription"
       :disabled="disabled || !limitsStore.limits"
       :maxlength="limitsStore.limits?.retrospective.description"

--- a/src/components/retrospective/RetrospectiveInputs.vue
+++ b/src/components/retrospective/RetrospectiveInputs.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+  import { useLimistStore } from '../../stores/limitsStore';
+  import BaseButton from '../core/BaseButton.vue';
+
+  const limitsStore = useLimistStore();
+
+  const { retroName, retroDescription } = defineProps<{
+    retroName: string;
+    retroDescription: string | undefined;
+    buttonLabel: string;
+    disabled: boolean;
+  }>();
+
+  const emit = defineEmits<{
+    'update:retroName': [string];
+    'update:retroDescription': [string];
+    clicked: [];
+  }>();
+</script>
+
+<template>
+  <div class="flex flex-col gap-2">
+    <label for="name" class="text-md font-bold text-gray-900">Name</label>
+    <input
+      id="name"
+      :value="retroName"
+      :disabled="disabled || !limitsStore.limits"
+      :maxlength="limitsStore.limits?.retrospective.name"
+      rows="4"
+      class="flex p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-75"
+      placeholder="When you were a child..."
+      @input="emit('update:retroName', ($event.target as HTMLInputElement).value)"
+    />
+
+    <label for="description" class="text-md font-bold text-gray-900">Description</label>
+    <textarea
+      id="description"
+      :value="retroDescription"
+      :disabled="disabled || !limitsStore.limits"
+      :maxlength="limitsStore.limits?.retrospective.description"
+      rows="4"
+      class="flex mb-5 p-2.5 w-full resize-none text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-75"
+      placeholder="Retrospective to talk about sprint 123, gather some feedback and be better!"
+      @input="emit('update:retroDescription', ($event.target as HTMLInputElement).value)"
+    />
+
+    <BaseButton
+      :disabled="
+        disabled ||
+        retroName.length < 5 ||
+        !limitsStore.limits ||
+        retroName.length > limitsStore.limits.retrospective.name ||
+        (retroDescription?.length ?? 0) > limitsStore.limits.retrospective.description
+      "
+      class="w-full"
+      @click="emit('clicked')"
+    >
+      {{ buttonLabel }}
+    </BaseButton>
+  </div>
+</template>

--- a/src/components/retrospective/RetrospectiveLayout.vue
+++ b/src/components/retrospective/RetrospectiveLayout.vue
@@ -23,10 +23,10 @@
   <template v-if="retrospective">
     <div class="flex flex-col">
       <div class="flex justify-between items-center">
-        <h1 class="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl">
+        <h1 class="text-3xl font-bold break-all tracking-tighter sm:text-4xl md:text-5xl">
           {{ retrospective.name }}
         </h1>
-        <div class="flex gap-2">
+        <div class="flex gap-2 ml-4">
           <ShareRetro />
           <RouterLink
             class="flex self-center flex-shrink-0"
@@ -37,7 +37,7 @@
         </div>
       </div>
 
-      <p v-if="retrospective.description" class="text-gray-500">
+      <p v-if="retrospective.description" class="text-gray-500 mb-10">
         {{ retrospective.description }}
       </p>
     </div>

--- a/src/components/retrospective/RetrospectiveLayout.vue
+++ b/src/components/retrospective/RetrospectiveLayout.vue
@@ -37,7 +37,7 @@
         </div>
       </div>
 
-      <p v-if="retrospective.description" class="text-gray-500 mb-10">
+      <p v-if="retrospective.description" class="text-gray-500 mb-10 break-all">
         {{ retrospective.description }}
       </p>
     </div>

--- a/src/components/retrospective/UpdateRetrospective.vue
+++ b/src/components/retrospective/UpdateRetrospective.vue
@@ -5,9 +5,14 @@
   import { NotificationType, useNotifyStore } from '../../stores/notifyStore';
   import { Retrospective, useRetrospectiveStore } from '../../stores/retrospectiveStore';
   import retrospectiveApi from '../../services/retrospectiveApi';
+  import { useLimistStore } from '../../stores/limitsStore';
+  import { storeToRefs } from 'pinia';
 
   const retroStore = useRetrospectiveStore();
   const notifyStore = useNotifyStore();
+  const limitsStore = useLimistStore();
+
+  const { limits } = storeToRefs(limitsStore);
 
   const isOpen = ref(false);
 
@@ -58,6 +63,8 @@
       <input
         id="name"
         v-model="updatedName"
+        :disabled="!limits"
+        :maxlength="limits?.retrospective.name"
         rows="4"
         class="flex p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-75"
         placeholder="When you were a child..."
@@ -67,12 +74,22 @@
       <textarea
         id="description"
         v-model="updatedDescription"
+        :disabled="!limits"
+        :maxlength="limits?.retrospective.description"
         rows="4"
         class="flex mb-5 p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-75"
         placeholder="Retrospective to talk about sprint 123, gather some feedback and be better!"
       />
 
-      <BaseButton :disabled="updatedName.length < 5" class="w-full" @click="updateRetrospective"
+      <BaseButton
+        :disabled="
+          updatedName.length < 5 ||
+          !limits ||
+          updatedName.length > limits.retrospective.name ||
+          (updatedDescription && updatedDescription.length > limits.retrospective.description)
+        "
+        class="w-full"
+        @click="updateRetrospective"
         >Update retrospective</BaseButton
       >
     </div>

--- a/src/components/retrospective/UpdateRetrospective.vue
+++ b/src/components/retrospective/UpdateRetrospective.vue
@@ -12,12 +12,12 @@
   const isOpen = ref(false);
   const disableInteraction = ref(false);
 
-  const { retrospective } = defineProps<{
+  const props = defineProps<{
     retrospective: Retrospective;
   }>();
 
-  const updatedName = ref(retrospective.name);
-  const updatedDescription = ref(retrospective.description);
+  const updatedName = ref(props.retrospective.name);
+  const updatedDescription = ref(props.retrospective.description);
 
   const toggleModal = () => {
     isOpen.value = !isOpen.value;
@@ -25,8 +25,8 @@
 
   const updateRetrospective = async () => {
     if (
-      updatedName.value === retrospective.name &&
-      updatedDescription.value === retrospective.description
+      updatedName.value === props.retrospective.name &&
+      updatedDescription.value === props.retrospective.description
     ) {
       isOpen.value = !isOpen.value;
       return;
@@ -34,7 +34,7 @@
 
     disableInteraction.value = true;
     const res = await retrospectiveApi.updateRetrospective({
-      id: retrospective.id,
+      id: props.retrospective.id,
       description: updatedDescription.value,
       name: updatedName.value,
     });

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -3,6 +3,7 @@ import { useRetrospectiveStore } from '../stores/retrospectiveStore';
 import retrospectiveApi from '../services/retrospectiveApi';
 import { useWebsocketStore } from '../stores/websocketStore';
 import logger from '../services/logger';
+import { useLimistStore } from '../stores/limitsStore';
 
 export const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -57,6 +58,7 @@ export const router = createRouter({
 
 router.beforeEach(async (to) => {
   const retroStore = useRetrospectiveStore();
+  const limitsStore = useLimistStore();
   const wsStore = useWebsocketStore();
   const retroId = to.params.id;
 
@@ -66,6 +68,8 @@ router.beforeEach(async (to) => {
     logger.debug('Closing current websocket');
     wsStore.close('The user left the retrospective', false);
   }
+
+  if (toName.includes('retrospective')) await limitsStore.fetchLimits();
 
   if (
     (retroStore.currentRetro === undefined && typeof retroId === 'string') ||

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -7,6 +7,7 @@ export enum Endpoints {
   Retrospective = '/retrospective',
   Answer = '/answer',
   SocketHello = '/hello',
+  Limits = '/limits',
 }
 
 export const apiRequest = axios.create({

--- a/src/services/limitsApi.ts
+++ b/src/services/limitsApi.ts
@@ -1,0 +1,24 @@
+import { Endpoints, MayBeError, apiRequest } from '.';
+
+export type Limits = {
+  retrospective: {
+    name: number;
+    description: number;
+  };
+  question: {
+    text: number;
+  };
+  answer: {
+    text: number;
+  };
+};
+
+const getLimits = async (): Promise<MayBeError<Limits>> => {
+  const result = await apiRequest.get(Endpoints.Limits).catch(() => null);
+
+  if (!result) return { error: true };
+
+  return result.data;
+};
+
+export default { getLimits };

--- a/src/services/limitsApi.ts
+++ b/src/services/limitsApi.ts
@@ -1,4 +1,6 @@
+import { AxiosError } from 'axios';
 import { Endpoints, MayBeError, apiRequest } from '.';
+import logger from './logger';
 
 export type Limits = {
   retrospective: {
@@ -14,7 +16,19 @@ export type Limits = {
 };
 
 const getLimits = async (): Promise<MayBeError<Limits>> => {
-  const result = await apiRequest.get(Endpoints.Limits).catch(() => null);
+  const result = await apiRequest.get(Endpoints.Limits).catch((e: AxiosError) => {
+    if (e?.response?.status === 404) {
+      logger.error('The limit route is not yet implemented. Using hardcoded ones');
+
+      return {
+        data: {
+          answer: { text: 300 },
+          question: { text: 100 },
+          retrospective: { name: 100, description: 300 },
+        },
+      };
+    }
+  });
 
   if (!result) return { error: true };
 

--- a/src/stores/limitsStore.ts
+++ b/src/stores/limitsStore.ts
@@ -7,6 +7,18 @@ export const useLimistStore = defineStore('limits', () => {
   const notifyStore = useNotifyStore();
   const limits = ref<Limits>();
 
+  // FIXME: remove this line. Do not allow it in commit
+  limits.value = {
+    answer: { text: 1000 },
+    question: {
+      text: 300,
+    },
+    retrospective: {
+      description: 300,
+      name: 80,
+    },
+  };
+
   const fetchLimits = async () => {
     if (typeof limits.value !== 'undefined') return;
 

--- a/src/stores/limitsStore.ts
+++ b/src/stores/limitsStore.ts
@@ -7,18 +7,6 @@ export const useLimistStore = defineStore('limits', () => {
   const notifyStore = useNotifyStore();
   const limits = ref<Limits>();
 
-  // FIXME: remove this line. Do not allow it in commit
-  limits.value = {
-    answer: { text: 1000 },
-    question: {
-      text: 300,
-    },
-    retrospective: {
-      description: 300,
-      name: 80,
-    },
-  };
-
   const fetchLimits = async () => {
     if (typeof limits.value !== 'undefined') return;
 

--- a/src/stores/limitsStore.ts
+++ b/src/stores/limitsStore.ts
@@ -1,0 +1,25 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import limitsApi, { Limits } from '../services/limitsApi';
+import { NotificationType, useNotifyStore } from './notifyStore';
+
+export const useLimistStore = defineStore('limits', () => {
+  const notifyStore = useNotifyStore();
+  const limits = ref<Limits>();
+
+  const fetchLimits = async () => {
+    if (typeof limits.value !== 'undefined') return;
+
+    const result = await limitsApi.getLimits();
+
+    if (result.error)
+      return notifyStore.notify(
+        "We couldn't get the data limits. Please retry",
+        NotificationType.Error,
+      );
+
+    limits.value = result;
+  };
+
+  return { limits, fetchLimits };
+});


### PR DESCRIPTION
In this PR, a couple of things were made. Here are what we did:

- Add limits in frontend to all inputs.
- Display all answers by default
- Fix the eye emoji shrink problem
- Fix all text overflow problems
- Parse line breaks correctly in answers
- Add a display to all inputs showing character limit
- Implement a GET to `/api/limits` to get all limits. The response body expects the following schema:
```
{
  retrospective: {
    name: number;
    description: number;
  };
  question: {
    text: number;
  };
  answer: {
    text: number;
  };
};
```

If the requests gets a 404 response, it uses the current API values, hardcoded in client. With this we can deploy the front even without a backend deploy