### PR TITLE
fix: footer requiring scroll on short content pages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -24,8 +24,10 @@
   <div>
     <ShortcutModal ref="shortcutRef" />
     <NotifyToast class="fixed bottom-0 left-0 z-50 p-4" />
-    <div class="container grid mx-auto px-4 pt-8 md:pt-12 md:px-6 min-h-screen">
-      <RouterView />
+    <div class="container flex flex-col mx-auto px-4 pt-8 md:pt-12 md:px-6 min-h-screen">
+      <div class="grow">
+        <RouterView />
+      </div>
       <FooterComponent />
     </div>
   </div>

--- a/src/views/AboutPage.vue
+++ b/src/views/AboutPage.vue
@@ -25,7 +25,7 @@
 <template>
   <ShortcutModal ref="jumpToRetro" />
 
-  <div class="min-h-screen">
+  <div>
     <div class="text-center">
       <img src="/logo_nobg.png" class="h-40 inline" />
       <h1 class="mt-4 text-4xl font-bold">Simple Retro</h1>


### PR DESCRIPTION
- Changed App.vue container from grid to flexbox layout
- Wrapped RouterView in a grow div to fill available space
- Removed min-h-screen from AboutPage that was causing double viewport height

Before:
<img width="1868" height="995" alt="image" src="https://github.com/user-attachments/assets/4574b67e-2c3d-4bd8-822e-a5337139007f" />

After:
<img width="1868" height="996" alt="image" src="https://github.com/user-attachments/assets/1abffb69-704b-46a6-bb71-3c2d5bef2a6c" />
